### PR TITLE
Lock for mappings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mockit (1.0.0)
+    mockit (1.0.1)
       rails (>= 6.0)
       request_store
 

--- a/lib/mockit.rb
+++ b/lib/mockit.rb
@@ -3,6 +3,7 @@
 require_relative "mockit/version"
 
 require "mockit/version"
+require "mockit/distributed_lock"
 require "mockit/store"
 require "mockit/railtie"
 require "mockit/engine"

--- a/lib/mockit/distributed_lock.rb
+++ b/lib/mockit/distributed_lock.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Mockit
+  # Distributed lock implementation using cache store
+  class DistributedLock
+    TIMEOUT = 10 # seconds
+
+    def initialize(storage, lock_key, timeout: TIMEOUT)
+      @storage = storage
+      @lock_key = lock_key
+      @timeout = timeout
+      @acquired = false
+    end
+
+    # Acquire the lock and execute the block
+    def synchronize
+      acquire_lock
+      yield
+    ensure
+      release_lock
+    end
+
+    private
+
+    attr_reader :storage, :lock_key, :timeout, :acquired
+
+    def acquire_lock
+      @lock_token = SecureRandom.uuid
+      deadline = Time.now + timeout
+
+      loop do
+        break if try_acquire_lock
+
+        raise_timeout_error if Time.now >= deadline
+
+        sleep(0.01 + (rand * 0.02))
+      end
+
+      @acquired = true
+    end
+
+    def try_acquire_lock
+      storage.write(lock_key, @lock_token, expires_in: timeout, unless_exist: true)
+    end
+
+    def raise_timeout_error
+      raise Mockit::Error, "Mockit: Failed to acquire lock on #{lock_key} within #{timeout} seconds"
+    end
+
+    def release_lock
+      return unless @acquired
+      return unless storage.read(lock_key) == @lock_token
+
+      storage.delete(lock_key)
+    end
+  end
+end

--- a/lib/mockit/store.rb
+++ b/lib/mockit/store.rb
@@ -3,6 +3,9 @@
 module Mockit
   # Wrapper for cache store
   class Store
+    MAPPINGS_LOCK_KEY = "mockit:mappings:lock"
+    LOCK_TIMEOUT = 10 # seconds
+
     # Store overrides for a service under the current request's mock id.
     #
     # @param service [String] service identifier
@@ -52,12 +55,14 @@ module Mockit
     # @param mock_id [String] mock id to associate
     # @param ttl [Integer] time-to-live in seconds for this mapping
     def self.write_mapping(match:, mock_id:, ttl: 3600)
-      mappings = read_mappings
-      mappings.reject! { |m| expired_mapping?(m) }
+      with_lock(MAPPINGS_LOCK_KEY) do
+        mappings = read_mappings
+        mappings.reject! { |m| expired_mapping?(m) }
 
-      mappings << { "id" => mock_id, "match" => match, "created_at" => Time.now.to_i, "ttl" => ttl }
+        mappings << { "id" => mock_id, "match" => match, "created_at" => Time.now.to_i, "ttl" => ttl }
 
-      Mockit.storage.write(MAPPINGS_KEY, mappings.to_json)
+        Mockit.storage.write(MAPPINGS_KEY, mappings.to_json)
+      end
     end
 
     # Read and return all non-expired mappings.
@@ -88,9 +93,11 @@ module Mockit
     #
     # @param mock_id [String]
     def self.delete_mapping(mock_id:)
-      mappings = read_mappings
-      mappings.reject! { |m| m["id"] == mock_id }
-      Mockit.storage.write(MAPPINGS_KEY, mappings.to_json)
+      with_lock(MAPPINGS_LOCK_KEY) do
+        mappings = read_mappings
+        mappings.reject! { |m| m["id"] == mock_id }
+        Mockit.storage.write(MAPPINGS_KEY, mappings.to_json)
+      end
     end
 
     # Returns whether a mapping has expired based on its `created_at` and `ttl`.
@@ -191,5 +198,43 @@ module Mockit
       # delete mappings that reference this mock id
       delete_mapping(mock_id: mock_id)
     end
+
+    # Distributed lock implementation using cache store.
+    # Acquires a lock, executes the block, and releases the lock.
+    #
+    # @param lock_key [String] the key to use for locking
+    # @param timeout [Integer] maximum time to wait for lock acquisition
+    # @yield block to execute while holding the lock
+    def self.with_lock(lock_key, timeout: LOCK_TIMEOUT)
+      lock_token = SecureRandom.uuid
+      deadline = Time.now + timeout
+      acquired = false
+
+      # Try to acquire lock with exponential backoff
+      loop do
+        # Try to set the lock key if it doesn't exist
+        if Mockit.storage.write(lock_key, lock_token, expires_in: LOCK_TIMEOUT, unless_exist: true)
+          acquired = true
+          break
+        end
+
+        # Check if we've exceeded the timeout
+        raise Mockit::Error, "Failed to acquire lock on #{lock_key} within #{timeout} seconds" if Time.now >= deadline
+
+        # Wait a bit before retrying (exponential backoff with jitter)
+        sleep(0.01 + (rand * 0.02))
+      end
+
+      # Execute the block while holding the lock
+      yield
+    ensure
+      # Release the lock only if we acquired it
+      # Check that our token is still in place to avoid releasing someone else's lock
+      if acquired
+        current_token = Mockit.storage.read(lock_key)
+        Mockit.storage.delete(lock_key) if current_token == lock_token
+      end
+    end
+    private_class_method :with_lock
   end
 end

--- a/lib/mockit/store.rb
+++ b/lib/mockit/store.rb
@@ -4,7 +4,6 @@ module Mockit
   # Wrapper for cache store
   class Store
     MAPPINGS_LOCK_KEY = "mockit:mappings:lock"
-    LOCK_TIMEOUT = 10 # seconds
 
     # Store overrides for a service under the current request's mock id.
     #
@@ -55,7 +54,7 @@ module Mockit
     # @param mock_id [String] mock id to associate
     # @param ttl [Integer] time-to-live in seconds for this mapping
     def self.write_mapping(match:, mock_id:, ttl: 3600)
-      with_lock(MAPPINGS_LOCK_KEY) do
+      DistributedLock.new(Mockit.storage, MAPPINGS_LOCK_KEY).synchronize do
         mappings = read_mappings
         mappings.reject! { |m| expired_mapping?(m) }
 
@@ -93,7 +92,7 @@ module Mockit
     #
     # @param mock_id [String]
     def self.delete_mapping(mock_id:)
-      with_lock(MAPPINGS_LOCK_KEY) do
+      DistributedLock.new(Mockit.storage, MAPPINGS_LOCK_KEY).synchronize do
         mappings = read_mappings
         mappings.reject! { |m| m["id"] == mock_id }
         Mockit.storage.write(MAPPINGS_KEY, mappings.to_json)
@@ -198,43 +197,5 @@ module Mockit
       # delete mappings that reference this mock id
       delete_mapping(mock_id: mock_id)
     end
-
-    # Distributed lock implementation using cache store.
-    # Acquires a lock, executes the block, and releases the lock.
-    #
-    # @param lock_key [String] the key to use for locking
-    # @param timeout [Integer] maximum time to wait for lock acquisition
-    # @yield block to execute while holding the lock
-    def self.with_lock(lock_key, timeout: LOCK_TIMEOUT)
-      lock_token = SecureRandom.uuid
-      deadline = Time.now + timeout
-      acquired = false
-
-      # Try to acquire lock with exponential backoff
-      loop do
-        # Try to set the lock key if it doesn't exist
-        if Mockit.storage.write(lock_key, lock_token, expires_in: LOCK_TIMEOUT, unless_exist: true)
-          acquired = true
-          break
-        end
-
-        # Check if we've exceeded the timeout
-        raise Mockit::Error, "Failed to acquire lock on #{lock_key} within #{timeout} seconds" if Time.now >= deadline
-
-        # Wait a bit before retrying (exponential backoff with jitter)
-        sleep(0.01 + (rand * 0.02))
-      end
-
-      # Execute the block while holding the lock
-      yield
-    ensure
-      # Release the lock only if we acquired it
-      # Check that our token is still in place to avoid releasing someone else's lock
-      if acquired
-        current_token = Mockit.storage.read(lock_key)
-        Mockit.storage.delete(lock_key) if current_token == lock_token
-      end
-    end
-    private_class_method :with_lock
   end
 end

--- a/lib/mockit/version.rb
+++ b/lib/mockit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mockit
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/mockit/controllers/mocks_controller_spec.rb
+++ b/spec/mockit/controllers/mocks_controller_spec.rb
@@ -97,7 +97,6 @@ RSpec.describe "Mockit::MocksController", type: :request do
       Mockit.storage.delete("mockit:mappings")
     end
 
-    # rubocop:disable Metrics/BlockLength
     it "deletes all mocks and mappings" do
       # set a mock under mock_id m-abc and another under m-other
       # create first mock with RequestStore set
@@ -141,7 +140,6 @@ RSpec.describe "Mockit::MocksController", type: :request do
       get "/mockit/mocks", params: { service: "svc2" }
       expect(response).to have_http_status(:ok)
     end
-    # rubocop:enable Metrics/BlockLength
   end
 
   describe "POST /mockit/map_request additional cases" do

--- a/spec/mockit/store_spec.rb
+++ b/spec/mockit/store_spec.rb
@@ -121,11 +121,39 @@ RSpec.describe Mockit::Store do
       old = { "id" => "old", "match" => { "path" => "^/x$" }, "created_at" => Time.now.to_i - 3600, "ttl" => 1 }
       Mockit.storage.write("mockit:mappings", [old].to_json)
 
-      described_class.write_mapping(match: { "path" => "^/new$" }, mock_id: "new", ttl: 10)
+      described_class.write_mapping(match: { "pat
+                                                   h" => "^/new$" }, mock_id: "new", ttl: 10)
       mappings = described_class.read_mappings
 
       expect(mappings.any? { |m| m["id"] == "old" }).to be false
       expect(mappings.any? { |m| m["id"] == "new" }).to be true
+    end
+
+    it "retries lock acquisition when contention occurs" do
+      call_count = 0
+      allow(Mockit.storage).to receive(:write) do |key, _value, _options|
+        if key == Mockit::Store::MAPPINGS_LOCK_KEY
+          call_count += 1
+          call_count > 1 # fail first time, succeed second time
+        else
+          true
+        end
+      end
+      allow(Mockit.storage).to receive(:read).and_return("[]")
+      allow(Mockit.storage).to receive(:delete)
+
+      described_class.write_mapping(match: { "path" => "^/test$" }, mock_id: "retry-test", ttl: 0.5)
+      expect(call_count).to eq(2)
+    end
+
+    it "raises error when lock acquisition times out" do
+      stub_const("Mockit::DistributedLock::TIMEOUT", 0.1) # set short timeout for test
+      allow(Mockit.storage).to receive(:write).with(Mockit::Store::MAPPINGS_LOCK_KEY, anything,
+                                                    anything).and_return(false)
+
+      expect do
+        described_class.write_mapping(match: { "path" => "^/timeout$" }, mock_id: "timeout-test", ttl: 0.5)
+      end.to raise_error(Mockit::Error, /Failed to acquire lock/)
     end
   end
 end


### PR DESCRIPTION
## **User description**
Problem
Race condition in `write_mapping` and `delete_mapping` when multiple processes/servers modify the mappings array concurrently. The read-modify-write pattern without synchronization causes lost updates:

Solution
Added distributed locking using the cache store's atomic operations to protect concurrent modifications:

Lock acquisition with unless_exist: true for atomic operation across Redis
UUID tokens prevent processes from releasing other processes' locks
10-second auto-expiration prevents deadlocks
Exponential backoff with jitter for lock contention
Both `write_mapping` and `delete_mapping`now execute within `with_lock` to ensure data consistency across distributed systems. All existing tests pass.


___

## **CodeAnt-AI Description**
Prevent lost mapping updates with distributed locking

### What Changed
- write_mapping and delete_mapping now run under a distributed lock so concurrent processes/servers no longer overwrite each other's mapping changes
- Lock uses the shared cache store with a 10‑second auto-expire and token checks to avoid releasing other processes' locks
- Library version bumped to 1.0.1

### Impact
`✅ Fewer lost mappings during concurrent requests`
`✅ Consistent mapping registry across multiple servers`
`✅ Fewer race-condition errors when updating mappings`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
