### PR TITLE
Support matching body and json_body

### DIFF
--- a/lib/mockit/middleware/mapping_matcher.rb
+++ b/lib/mockit/middleware/mapping_matcher.rb
@@ -12,19 +12,14 @@ module Mockit
       # - "headers": hash of header_name => regex_or_value (regex string or literal)
       # - "params": hash of param_name => regex_or_value matched against query string
       def self.match?(mapping, env)
-        match = mapping["match"] || {}
-
-        path = match_path?(match, env)
-        remote = match_remote?(match, env)
-        headers = match_headers?(match, env)
-        params = match_params?(match, env)
-
-        Mockit.logger.debug <<-INFO
-          Mockit Match #{env}: path #{path}; remote #{remote}; headers #{headers}; params #{params}.
-          Mapping: #{mapping}
-        INFO
-
-        path && remote && headers && params
+        m = mapping["match"] || {}
+        results = {
+          path: match_path?(m, env), remote: match_remote?(m, env),
+          headers: match_headers?(m, env), params: match_params?(m, env),
+          body: match_body?(m, env), body_json: match_body_json?(m, env)
+        }
+        Mockit.logger.debug("Mockit Match #{env}: #{results}. Mapping: #{mapping}")
+        results.values.all?
       end
 
       def self.match_path?(match, env)
@@ -44,23 +39,14 @@ module Mockit
       def self.match_headers?(match, env)
         return true unless match["headers"].is_a?(Hash)
 
-        match["headers"].each do |h_name, h_val|
-          return false unless match_header_entry?(h_name, h_val, env)
-        end
-
-        true
+        match["headers"].all? { |h_name, h_val| match_header_entry?(h_name, h_val, env) }
       end
 
       def self.match_params?(match, env)
         return true unless match["params"].is_a?(Hash)
 
         params_hash = parse_query(env)
-
-        match["params"].each do |p_name, p_val|
-          return false unless match_param_entry?(p_name, p_val, params_hash)
-        end
-
-        true
+        match["params"].all? { |p_name, p_val| match_param_entry?(p_name, p_val, params_hash) }
       end
 
       def self.match_header_entry?(h_name, h_val, env)
@@ -89,9 +75,54 @@ module Mockit
       end
 
       def self.header_request_value(env, h_name)
-        val = env["HTTP_#{h_name.upcase.tr("-", "_")}"]
-        val = val.to_s unless val.nil?
-        val
+        env["HTTP_#{h_name.upcase.tr("-", "_")}"]&.to_s
+      end
+
+      def self.match_body?(match, env)
+        return true unless match["body"]
+
+        safe_regex_match(read_body(env), match["body"])
+      end
+
+      def self.match_body_json?(match, env)
+        return true unless match["body_json"].is_a?(Hash)
+
+        parsed = JSON.parse(read_body(env))
+        match_json_node?(match["body_json"], parsed)
+      rescue JSON::ParserError
+        false
+      end
+
+      def self.match_json_node?(pattern, value)
+        case pattern
+        when Hash  then match_json_hash?(pattern, value)
+        when Array then match_json_array?(pattern, value)
+        else            match_value_with_pattern(value&.to_s, pattern)
+        end
+      end
+
+      def self.match_json_hash?(pattern, value)
+        return false unless value.is_a?(Hash)
+
+        pattern.all? { |key, sub| match_json_node?(sub, value[key.to_s]) }
+      end
+
+      def self.match_json_array?(pattern, value)
+        return false unless value.is_a?(Array)
+
+        pattern.each_with_index.all? { |sub, i| match_json_node?(sub, value[i]) }
+      end
+
+      def self.read_body(env)
+        env["mockit.body"] ||= read_rack_body(env["rack.input"])
+      end
+
+      def self.read_rack_body(input)
+        return "" unless input
+
+        body = input.read
+        input.rewind
+        body
       end
 
       def self.parse_query(env)

--- a/spec/e2e/body_matching_e2e_spec.rb
+++ b/spec/e2e/body_matching_e2e_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+
+RSpec.describe "Body Matching E2E", type: :request do
+  let(:mock_id) { "body-e2e-test" }
+  let(:mockit_header) { { "HTTP_X_MOCKIT_ID" => mock_id } }
+
+  after do
+    delete "/mockit/mocks/teardown", headers: mockit_header, as: :json
+    RequestStore.store.clear
+  end
+
+  def create_mapping(match)
+    post "/mockit/map_request",
+         params: { match: match, ttl: 60 },
+         headers: mockit_header,
+         as: :json
+    expect(response).to have_http_status(:ok)
+  end
+
+  def probe(body)
+    post "/probe", params: body, as: :json
+    JSON.parse(response.body)["mock_id"]
+  end
+
+  describe "body regex matching" do
+    it "activates mapping when raw body matches regex" do
+      create_mapping("body" => "create")
+      expect(probe({ action: "create", user_id: 42 })).to eq(mock_id)
+    end
+
+    it "does not activate mapping when raw body does not match" do
+      create_mapping("body" => "^create$")
+      expect(probe({ action: "create", user_id: 42 })).to be_nil
+    end
+
+    it "does not activate mapping when body is unrelated" do
+      create_mapping("body" => "delete")
+      expect(probe({ action: "create" })).to be_nil
+    end
+  end
+
+  describe "body_json matching" do
+    it "activates mapping when flat JSON key matches" do
+      create_mapping("body_json" => { "action" => "create" })
+      expect(probe({ action: "create", extra: "ignored" })).to eq(mock_id)
+    end
+
+    it "does not activate mapping when flat JSON value does not match" do
+      create_mapping("body_json" => { "action" => "delete" })
+      expect(probe({ action: "create" })).to be_nil
+    end
+
+    it "activates mapping when nested JSON structure matches" do
+      create_mapping("body_json" => { "user" => { "role" => "admin" } })
+      expect(probe({ user: { role: "admin", name: "Alice" } })).to eq(mock_id)
+    end
+
+    it "does not activate mapping when nested value does not match" do
+      create_mapping("body_json" => { "user" => { "role" => "admin" } })
+      expect(probe({ user: { role: "viewer" } })).to be_nil
+    end
+
+    it "activates mapping combining body_json with path" do
+      create_mapping("path" => "^/probe$", "body_json" => { "action" => "create" })
+      expect(probe({ action: "create" })).to eq(mock_id)
+    end
+
+    it "does not activate when path matches but body_json does not" do
+      create_mapping("path" => "^/probe$", "body_json" => { "action" => "delete" })
+      expect(probe({ action: "create" })).to be_nil
+    end
+  end
+end

--- a/spec/mockit/middleware/mapping_matcher_spec.rb
+++ b/spec/mockit/middleware/mapping_matcher_spec.rb
@@ -56,4 +56,85 @@ RSpec.describe Mockit::Middleware::MappingMatcher do
     env = { "PATH_INFO" => "/anything", "QUERY_STRING" => "page=2" }
     expect(described_class.match?(mapping, env)).to be true
   end
+
+  def env_with_body(body, extra = {})
+    { "PATH_INFO" => "/anything", "rack.input" => StringIO.new(body) }.merge(extra)
+  end
+
+  describe "body matching" do
+    it "matches raw body with regex" do
+      mapping = { "match" => { "body" => "hello" } }
+      expect(described_class.match?(mapping, env_with_body("say hello world"))).to be true
+    end
+
+    it "returns false when raw body does not match regex" do
+      mapping = { "match" => { "body" => "^hello$" } }
+      expect(described_class.match?(mapping, env_with_body("say hello world"))).to be false
+    end
+
+    it "rewinds rack.input so body is readable after matching" do
+      mapping = { "match" => { "body" => "hello" } }
+      input = StringIO.new("hello")
+      env = { "PATH_INFO" => "/anything", "rack.input" => input }
+      described_class.match?(mapping, env)
+      expect(input.read).to eq("hello")
+    end
+
+    it "returns true when no body key in match" do
+      mapping = { "match" => {} }
+      expect(described_class.match?(mapping, env_with_body("anything"))).to be true
+    end
+  end
+
+  describe "body_json matching" do
+    it "matches flat JSON key with regex" do
+      mapping = { "match" => { "body_json" => { "action" => "^create$" } } }
+      expect(described_class.match?(mapping, env_with_body('{"action":"create"}'))).to be true
+    end
+
+    it "returns false when flat JSON key does not match" do
+      mapping = { "match" => { "body_json" => { "action" => "^delete$" } } }
+      expect(described_class.match?(mapping, env_with_body('{"action":"create"}'))).to be false
+    end
+
+    it "matches nested JSON hash" do
+      mapping = { "match" => { "body_json" => { "user" => { "address" => { "city" => "New York" } } } } }
+      body = '{"user":{"address":{"city":"New York"},"name":"John"}}'
+      expect(described_class.match?(mapping, env_with_body(body))).to be true
+    end
+
+    it "returns false when nested value does not match" do
+      mapping = { "match" => { "body_json" => { "user" => { "address" => { "city" => "Boston" } } } } }
+      body = '{"user":{"address":{"city":"New York"}}}'
+      expect(described_class.match?(mapping, env_with_body(body))).to be false
+    end
+
+    it "ignores extra keys in body not specified in pattern" do
+      mapping = { "match" => { "body_json" => { "action" => "create" } } }
+      body = '{"action":"create","unrelated":"stuff"}'
+      expect(described_class.match?(mapping, env_with_body(body))).to be true
+    end
+
+    it "matches array values positionally" do
+      mapping = { "match" => { "body_json" => { "ids" => %w[1 2] } } }
+      body = '{"ids":["1","2","3"]}'
+      expect(described_class.match?(mapping, env_with_body(body))).to be true
+    end
+
+    it "returns false when positional array element does not match" do
+      mapping = { "match" => { "body_json" => { "ids" => %w[1 9] } } }
+      body = '{"ids":["1","2","3"]}'
+      expect(described_class.match?(mapping, env_with_body(body))).to be false
+    end
+
+    it "returns false on invalid JSON" do
+      mapping = { "match" => { "body_json" => { "action" => "create" } } }
+      expect(described_class.match?(mapping, env_with_body("not json"))).to be false
+    end
+
+    it "returns true when no body_json key in match" do
+      mapping = { "match" => {} }
+      expect(described_class.match?(mapping, env_with_body('{"action":"create"}'))).to be true
+    end
+  end
 end

--- a/spec/mockit/middleware_spec.rb
+++ b/spec/mockit/middleware_spec.rb
@@ -33,6 +33,65 @@ RSpec.describe Mockit::Middleware do
       expect(captured[:mock_id]).to be_nil
     end
 
+    it "sets mock_id when body matches regex" do
+      mapping = { "id" => "body-mock", "match" => { "body" => "hello" }, "created_at" => Time.now.to_i, "ttl" => 3600 }
+      allow(Mockit::Store).to receive(:read_mappings).and_return([mapping])
+
+      env = { "PATH_INFO" => "/anything", "rack.input" => StringIO.new("say hello world") }
+      middleware.call(env)
+      expect(captured[:mock_id]).to eq("body-mock")
+    end
+
+    it "does not set mock_id when body does not match regex" do
+      mapping = { "id" => "body-mock", "match" => { "body" => "^hello$" }, "created_at" => Time.now.to_i,
+                  "ttl" => 3600 }
+      allow(Mockit::Store).to receive(:read_mappings).and_return([mapping])
+
+      env = { "PATH_INFO" => "/anything", "rack.input" => StringIO.new("say hello world") }
+      middleware.call(env)
+      expect(captured[:mock_id]).to be_nil
+    end
+
+    it "sets mock_id when body_json matches nested structure" do
+      mapping = {
+        "id" => "json-mock",
+        "match" => { "body_json" => { "user" => { "role" => "admin" } } },
+        "created_at" => Time.now.to_i,
+        "ttl" => 3600
+      }
+      allow(Mockit::Store).to receive(:read_mappings).and_return([mapping])
+
+      body = '{"user":{"role":"admin","name":"Alice"}}'
+      env = { "PATH_INFO" => "/anything", "rack.input" => StringIO.new(body) }
+      middleware.call(env)
+      expect(captured[:mock_id]).to eq("json-mock")
+    end
+
+    it "does not set mock_id when body_json value does not match" do
+      mapping = {
+        "id" => "json-mock",
+        "match" => { "body_json" => { "user" => { "role" => "admin" } } },
+        "created_at" => Time.now.to_i,
+        "ttl" => 3600
+      }
+      allow(Mockit::Store).to receive(:read_mappings).and_return([mapping])
+
+      body = '{"user":{"role":"viewer"}}'
+      env = { "PATH_INFO" => "/anything", "rack.input" => StringIO.new(body) }
+      middleware.call(env)
+      expect(captured[:mock_id]).to be_nil
+    end
+
+    it "does not set mock_id when body_json is not valid JSON" do
+      mapping = { "id" => "json-mock", "match" => { "body_json" => { "action" => "create" } },
+                  "created_at" => Time.now.to_i, "ttl" => 3600 }
+      allow(Mockit::Store).to receive(:read_mappings).and_return([mapping])
+
+      env = { "PATH_INFO" => "/anything", "rack.input" => StringIO.new("not json") }
+      middleware.call(env)
+      expect(captured[:mock_id]).to be_nil
+    end
+
     it "logs and skips when read_mappings raises" do
       allow(Mockit::Store).to receive(:read_mappings).and_raise(StandardError.new("boom"))
       expect(Mockit.logger).to receive(:error).with(/MappingFilter error, skipping mappings/)

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -20,6 +20,7 @@ module TestApp
     initializer :append_routes do |app|
       app.routes.append do
         get "/ping", to: ->(_env) { [200, { "Content-Type" => "text/plain" }, ["pong"]] }
+        post "/probe", to: ->(_env) { [200, { "Content-Type" => "application/json" }, [{ mock_id: Mockit::Store.current_mock_id }.to_json]] }
         mount Mockit::Engine => "/mockit"
       end
     end


### PR DESCRIPTION
## **User description**
Add support for JSON body match


___

## **CodeAnt-AI Description**
**Support matching requests by body text and JSON content**

### What Changed
- Requests can now be matched by raw body text, so routes can respond only when the request body contains a specific pattern
- Requests can also be matched by JSON body content, including nested fields and array values
- Extra JSON fields no longer block a match as long as the requested parts line up
- Invalid JSON now fails the match instead of being treated as a valid body match
- Added coverage for body and JSON matching, including read-after-match behavior

### Impact
`✅ More precise request routing`
`✅ Clearer handling of JSON-based mocks`
`✅ Fewer mismatches for requests with extra JSON fields`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
